### PR TITLE
Impedir atalho duplicado

### DIFF
--- a/scripts/menus/input_settings.gd
+++ b/scripts/menus/input_settings.gd
@@ -10,8 +10,9 @@ const CONFIG_SECTION_INPUT := "input"
 var is_remapping: bool = false
 var action_to_remap: String = ""
 var remapping_button: Node = null
+var remap_armed : bool = false
 
-# Obs.: o InputMap precisa ter essas ações previamente criadas (Project Settings).
+# Obs.: o InputMap precisa ter essas ações preventiamente criadas (Project Settings).
 var input_actions := {
 	"move_up": "Move up",
 	"move_right": "Move right",
@@ -49,9 +50,14 @@ func _on_reset_button_pressed() -> void:
 func _on_input_button_pressed(button: Node, action: String) -> void:
 	if not is_remapping:
 		is_remapping = true
+		remap_armed = false
 		action_to_remap = action
 		remapping_button = button
+		
+		# limpa estado visual anterior, se houver
+		_set_error_ui(button, false)
 		button.find_child("LabelInput").text = "Press key to bind..."
+		call_deferred("_enable_remap_capture")
 
 
 # ---------------------------------------------------------------------
@@ -94,21 +100,56 @@ func _update_action_list(button: Node, event: InputEvent) -> void:
 # - Aplica no InputMap, atualiza a linha e sai do modo de remapeamento.
 # ---------------------------------------------------------------------
 func _input(event: InputEvent) -> void:
-	if is_remapping and (event is InputEventKey or (event is InputEventMouseButton and event.pressed)):
-		if event is InputEventMouseButton and event.double_click:
-			event.double_click = false
+	# só captura se estiver remapeando
+	if not is_remapping or not remap_armed:
+		return
+	
+	# --- Allowlist dos tipos aceitos ---
+	var is_key := event is InputEventKey
+	var is_mouse_btn := event is InputEventMouseButton
+	var is_pad_btn := event is InputEventJoypadButton
+	
+	if not (is_key or is_mouse_btn or is_pad_btn):
+		return
+	
+	if is_key and not event.pressed:
+		return
+	if is_mouse_btn and not event.pressed:
+		return
+	if is_pad_btn and not event.pressed:
+		return
+	
+	# evita duplicidade por double click no mouse
+	if is_mouse_btn and event.double_click:
+		event.double_click = false
+	
+	var conflict_with := _is_event_in_use(event, action_to_remap)
+	if conflict_with != "":
+		if remapping_button:
+			var label := remapping_button.find_child("LabelInput")
+			if label:
+				label.text = "Shortcut already in use. Try another one."
+			_set_error_ui(remapping_button, true)
 		
-		# substitui todos os eventos da ação
-		InputMap.action_erase_events(action_to_remap)
-		InputMap.action_add_event(action_to_remap, event)
-		_update_action_list(remapping_button, event)
-		
-		is_remapping = false
-		action_to_remap = ""
-		remapping_button = null
-		
-		# evita propagação do input para outros nós
 		accept_event()
+		return
+	
+	# aplica o novo atalho
+	InputMap.action_erase_events(action_to_remap)
+	InputMap.action_add_event(action_to_remap, event)
+	_update_action_list(remapping_button, event)
+	
+	# restaura UI (cor padrão + largura original)
+	if remapping_button:
+		_set_error_ui(remapping_button, false)
+		
+	# encerra remapeamento
+	is_remapping = false
+	remap_armed = false
+	action_to_remap = ""
+	remapping_button = null
+	
+	accept_event()
 
 
 # ---------------------------------------------------------------------
@@ -208,3 +249,95 @@ func _deserialize_event(event_data: Dictionary) -> InputEvent:
 func _delete_user_file() -> void:
 	if FileAccess.file_exists(SAVE_PATH):
 		DirAccess.remove_absolute(SAVE_PATH)
+
+
+# -----------------------------------------------------------------------------
+# Ativa a captura de entradas no próximo frame para o fluxo de remapeamento.
+# Contexto:
+#   - Deve ser chamada via `call_deferred("_enable_remap_capture")` logo após
+#     o usuário clicar no botão de remap (evita capturar o próprio clique/motion).
+# Efeito:
+#   - Define `remap_armed = true`, habilitando o `_input()` a processar a próxima
+#     tecla/botão pressionado como novo atalho.
+# -----------------------------------------------------------------------------
+func _enable_remap_capture() -> void:
+	remap_armed = true
+
+
+# -----------------------------------------------------------------------------
+# Gera uma “assinatura” estável para um InputEvent, usada na detecção de conflitos.
+# Parâmetros:
+#   - event (InputEvent): evento capturado pelo Godot.
+# Retorno:
+#   - String: assinatura normalizada (ex.: "key:87:0:0:0:0" ou "mouse:1:0").
+# Observações:
+#   - Posição/velocidade de mouse NÃO entram no cálculo (evita falsos positivos).
+# -----------------------------------------------------------------------------
+func _event_signature(event: InputEvent) -> String:
+	if event is InputEventKey:
+		return "key:%d:%d:%d:%d:%d" % [
+			int(event.physical_keycode),
+			int(event.alt_pressed),
+			int(event.shift_pressed),
+			int(event.ctrl_pressed),
+			int(event.meta_pressed),
+		]
+	elif event is InputEventMouseButton:
+		return "mouse:%d:%d" % [
+			int(event.button_index),
+			int(event.double_click)
+		]
+	return "unknown"
+
+
+# -----------------------------------------------------------------------------
+# Verifica se um determinado evento já está em uso por alguma ação (conflito).
+#   - Calcula a assinatura do `new_event`.
+#   - Percorre todas as ações em `input_actions` (exceto `except_action`) e
+#     compara com as assinaturas dos eventos registrados no InputMap.
+# Parâmetros:
+#   - new_event (InputEvent): evento que se deseja atribuir.
+#   - except_action (String): nome da ação atualmente sendo remapeada (ignorada).
+# Retorno:
+#   - String: nome da ação em conflito (se houver), ou "" se não houver conflito.
+# -----------------------------------------------------------------------------
+func _is_event_in_use(new_event: InputEvent, except_action: String) -> String:
+	var target_signature := _event_signature(new_event)
+	for action_name in input_actions.keys():
+		if action_name == except_action:
+			continue
+		for event in InputMap.action_get_events(action_name):
+			if _event_signature(event) == target_signature:
+				return action_name
+	return ""
+
+
+# -----------------------------------------------------------------------------
+# Liga/Desliga o estado visual de erro na linha (botão/row) do remapeamento.
+# Parâmetros:
+#   - line_button (Node): nó raiz da linha/botão que contém "LabelInput" e "LeftColumn".
+#   - is_error (bool): true para aplicar estilo de erro; false para restaurar.
+#   - A expansão usa `custom_minimum_size.x` e dispara novo layout automaticamente.
+# -----------------------------------------------------------------------------
+func _set_error_ui(line_button: Node, is_error: bool) -> void:
+	var label: Label = line_button.find_child("LabelInput")
+	var left_column: Control = line_button.find_child("LeftColumn")
+
+	if is_error:
+		if label:
+			label.add_theme_color_override("font_color", Color(1, 0.3, 0.1))
+		if left_column:
+			# guarda o tamanho original uma única vez
+			if not left_column.has_meta("orig_min_x"):
+				left_column.set_meta("orig_min_x", left_column.custom_minimum_size.x)
+			# garante espaço pro texto de erro
+			var padding := 16.0
+			var needed = (label if label else line_button).get_minimum_size().x + padding
+			left_column.custom_minimum_size.x = max(left_column.custom_minimum_size.x, needed)
+	else:
+		if label:
+			# volta à cor padrão do tema
+			label.remove_theme_color_override("font_color") 
+		if left_column and left_column.has_meta("orig_min_x"):
+			left_column.custom_minimum_size.x = float(left_column.get_meta("orig_min_x"))
+			left_column.remove_meta("orig_min_x")


### PR DESCRIPTION
## Descrição

* Impedir o usuário de configurar a mesma tecla para mais de uma ação no jogo.
* Ex.: "w" sendo usado para ir para cima e ir para baixo
* Quando o usuário escolher "w" pela segunda vez aparece uma mensagem de erro escrito "shortcut already in use."

## Ações nas issues
Relates to #49 
Closes #49 