### PR TITLE
 Quando o jogo reinicia as moedas não estão sendo limpas

### DIFF
--- a/scripts/game/asteroid.gd
+++ b/scripts/game/asteroid.gd
@@ -112,7 +112,12 @@ func asteroid_destruction() -> void:
 func add_new_ore() -> void:
 	var new_ore = ORE.instantiate()
 	new_ore.global_position = global_position
-	get_tree().current_scene.call_deferred("add_child", new_ore)
+	if not new_ore.is_in_group("ore"):
+		new_ore.add_to_group("ore")
+	if is_instance_valid(Singleton.level):
+		Singleton.level.call_deferred("add_child", new_ore)
+	else:
+		get_tree().current_scene.call_deferred("add_child", new_ore)
 
 
 ## Aplica dano ao asteroide.

--- a/scripts/globals/singleton.gd
+++ b/scripts/globals/singleton.gd
@@ -225,6 +225,9 @@ func restart_game() -> void:
 		return
 	get_tree().paused = true
 	_reset_all_bonuses_and_hide_picker()
+	for node in get_tree().get_nodes_in_group("ore"):
+		if is_instance_valid(node):
+			node.queue_free()
 	if gui_manager:
 		gui_manager.game_over_screen.visible = false
 	change_level(current_level_path)


### PR DESCRIPTION
## Descrição

Avance na partida deixando diversas moedas pelo mapa.

Morra.

Ao iniciar uma nova partida o mapa deveria estar limpo das moedas anteriores.

## Ações nas issues

* Relates to #106 
* Closes #106 